### PR TITLE
feat: Enhance archive pages with M3 card grid layout

### DIFF
--- a/web/app/themes/charity-m3-theme/resources/views/archive.blade.php
+++ b/web/app/themes/charity-m3-theme/resources/views/archive.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+  <div class="container mx-auto py-8">
+    {{-- Use the existing page-header partial to display the archive title --}}
+    @include('partials.page-header')
+
+    @if (!have_posts())
+      <div class="alert alert-warning">
+        {{ __('Sorry, no results were found.', 'charity-m3') }}
+      </div>
+      {!! get_search_form(false) !!}
+    @else
+      <x-m3.grid cols="responsive-default" gap="6">
+        @while(have_posts()) @php(the_post())
+          @include('partials.card-post', ['subtitle_context' => get_the_date()])
+        @endwhile
+      </x-m3.grid>
+
+      <div class="mt-8">
+        {!! get_the_posts_navigation() !!}
+      </div>
+    @endif
+  </div>
+@endsection

--- a/web/app/themes/charity-m3-theme/resources/views/index.blade.php
+++ b/web/app/themes/charity-m3-theme/resources/views/index.blade.php
@@ -9,10 +9,14 @@
       {!! get_search_form(false) !!}
     @endif
 
-    @while(have_posts()) @php(the_post())
-      @includeFirst(['partials.content-' . get_post_type(), 'partials.content'])
-    @endwhile
+    <x-m3.grid cols="responsive-default" gap="6">
+      @while(have_posts()) @php(the_post())
+        @include('partials.card-post', ['subtitle_context' => get_the_date()])
+      @endwhile
+    </x-m3.grid>
 
-    {!! get_the_posts_navigation() !!}
+    <div class="mt-8">
+      {!! get_the_posts_navigation() !!}
+    </div>
   </div>
 @endsection

--- a/web/app/themes/charity-m3-theme/resources/views/partials/card-post.blade.php
+++ b/web/app/themes/charity-m3-theme/resources/views/partials/card-post.blade.php
@@ -1,0 +1,34 @@
+@php
+  // This partial assumes it's being called inside The Loop.
+  // It can be passed optional context, e.g., for the subtitle.
+  $subtitle_context = $subtitle_context ?? get_the_date(); // Default to date if no context passed
+
+  $card_data = [
+      'title' => get_the_title(),
+      'subtitle' => $subtitle_context,
+      'imageUrl' => has_post_thumbnail() ? get_the_post_thumbnail_url(get_the_ID(), 'medium_large') : 'https://picsum.photos/seed/' . get_the_ID() . '/600/400', // Placeholder
+      'imageAlt' => has_post_thumbnail() ? get_the_post_thumbnail_caption() ?: get_the_title() : get_the_title(),
+      'href' => get_permalink(),
+      'variant' => 'outlined',
+      'interactive' => true,
+  ];
+@endphp
+
+<x-m3.card
+  :title="$card_data['title']"
+  :subtitle="$card_data['subtitle']"
+  :image-url="$card_data['imageUrl']"
+  :image-alt="$card_data['imageAlt']"
+  :href="$card_data['href']"
+  :variant="$card_data['variant']"
+  :interactive="$card_data['interactive']"
+  class="h-full flex flex-col" {{-- Make card flex-col to push actions to bottom --}}
+>
+  <div class="flex-grow"> {{-- This div will expand, pushing actions down --}}
+    {!! get_the_excerpt() !!}
+  </div>
+
+  <x-slot name="actions">
+    <x-m3.button type="text" href="{{ get_permalink() }}">{{ __('Read More', 'charity-m3') }}</x-m3.button>
+  </x-slot>
+</x-m3.card>

--- a/web/app/themes/charity-m3-theme/resources/views/search.blade.php
+++ b/web/app/themes/charity-m3-theme/resources/views/search.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('content')
+  <div class="container mx-auto py-8">
+    {{-- Use the existing page-header partial to display the search results title --}}
+    @include('partials.page-header')
+
+    @if (!have_posts())
+      <div class="alert alert-warning mb-8">
+        <p>{{ __('Sorry, no results were found for your search query.', 'charity-m3') }}</p>
+      </div>
+      <div class="max-w-md">
+        <h3 class="md-typescale-title-medium mb-4">{{ __('Try a new search?', 'charity-m3') }}</h3>
+        {!! get_search_form(false) !!}
+      </div>
+    @else
+      <x-m3.grid cols="responsive-default" gap="6">
+        @while(have_posts()) @php(the_post())
+          @include('partials.card-post', ['subtitle_context' => get_post_type() . ' | ' . get_the_date()])
+        @endwhile
+      </x-m3.grid>
+
+      <div class="mt-8">
+        {!! get_the_posts_navigation() !!}
+      </div>
+    @endif
+  </div>
+@endsection


### PR DESCRIPTION
Refactors the main blog index, generic archive, and search results pages to display posts in a responsive Material Design 3 styled card grid.

Key changes:
- Modified index.blade.php, archive.blade.php, and search.blade.php to use the `<x-m3.grid>` and `<x-m3.card>` Blade components.
- Created a reusable `partials.card-post.blade.php` partial to render a single post as an M3 card, making the templates DRY and easier to maintain.
- The new layout automatically applies to category, tag, author, date, and search result pages, ensuring a consistent user experience.
- Post data (featured image, title, excerpt, etc.) is dynamically mapped to card component props.
- Placeholder images are used for posts without a featured image to maintain grid integrity.