### PR TITLE
feat: Add Carousel/Slider component and Gutenberg block

### DIFF
--- a/web/app/themes/charity-m3-theme/app/Blocks/Carousel/block.json
+++ b/web/app/themes/charity-m3-theme/app/Blocks/Carousel/block.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "charity-m3/carousel",
+  "title": "Carousel / Slider (M3)",
+  "category": "charity-m3-components",
+  "description": "A responsive carousel or slider for displaying any type of content (images, cards, etc.).",
+  "keywords": ["carousel", "slider", "gallery", "swiper", "m3"],
+  "icon": "images-alt2",
+  "textdomain": "charity-m3",
+  "attributes": {
+    "slidesPerView": {
+      "type": "number",
+      "default": 1
+    },
+    "spaceBetween": {
+      "type": "number",
+      "default": 16
+    },
+    "loop": {
+      "type": "boolean",
+      "default": false
+    },
+    "autoplay": {
+      "type": "boolean",
+      "default": false
+    },
+    "delay": {
+      "type": "number",
+      "default": 3000
+    },
+    "showNavigation": {
+      "type": "boolean",
+      "default": true
+    },
+    "showPagination": {
+      "type": "boolean",
+      "default": true
+    },
+    "effect": {
+      "type": "string",
+      "default": "slide"
+    },
+    "allowedBlocks": {
+        "type": "array"
+        // No default, allowing any block by default unless specified in edit.js
+    }
+  },
+  "supports": {
+    "html": false,
+    "align": ["wide", "full"]
+  },
+  "editorScript": "charity-m3-carousel-editor-script"
+}

--- a/web/app/themes/charity-m3-theme/app/Blocks/Carousel/edit.js
+++ b/web/app/themes/charity-m3-theme/app/Blocks/Carousel/edit.js
@@ -1,0 +1,129 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+    useBlockProps,
+    InspectorControls,
+    InnerBlocks,
+} from '@wordpress/block-editor';
+import {
+    PanelBody,
+    ToggleControl,
+    RangeControl,
+    SelectControl,
+    TextControl,
+} from '@wordpress/components';
+
+import metadata from './block.json';
+
+const ALLOWED_BLOCKS = true; // Allow any block for maximum flexibility
+
+// A simple template to guide users
+const CAROUSEL_TEMPLATE = [
+    ['core/image', {}],
+    ['core/image', {}],
+    ['charity-m3/card-item', { title: 'Card Slide Example' }],
+];
+
+
+export default function Edit({ attributes, setAttributes }) {
+    const {
+        slidesPerView,
+        spaceBetween,
+        loop,
+        autoplay,
+        delay,
+        showNavigation,
+        showPagination,
+        effect,
+    } = attributes;
+
+    const blockProps = useBlockProps({
+        className: 'wp-block-charity-m3-carousel--editor-preview',
+        style: {
+            border: '2px dashed #938F99', // M3 outline color
+            padding: '1rem',
+        }
+    });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Carousel Settings', 'charity-m3')}>
+                    <RangeControl
+                        label={__('Slides Per View', 'charity-m3')}
+                        value={slidesPerView}
+                        onChange={(val) => setAttributes({ slidesPerView: val })}
+                        min={1}
+                        max={6}
+                        step={1}
+                    />
+                    <RangeControl
+                        label={__('Space Between Slides (px)', 'charity-m3')}
+                        value={spaceBetween}
+                        onChange={(val) => setAttributes({ spaceBetween: val })}
+                        min={0}
+                        max={64}
+                        step={4}
+                    />
+                    <SelectControl
+                        label={__('Transition Effect', 'charity-m3')}
+                        value={effect}
+                        options={[
+                            { label: 'Slide', value: 'slide' },
+                            { label: 'Fade', value: 'fade' },
+                            { label: 'Cube', value: 'cube' },
+                            { label: 'Coverflow', value: 'coverflow' },
+                            { label: 'Flip', value: 'flip' },
+                        ]}
+                        onChange={(val) => setAttributes({ effect: val })}
+                    />
+                </PanelBody>
+                <PanelBody title={__('Controls & Behavior', 'charity-m3')}>
+                    <ToggleControl
+                        label={__('Show Navigation Arrows', 'charity-m3')}
+                        checked={showNavigation}
+                        onChange={(val) => setAttributes({ showNavigation: val })}
+                    />
+                    <ToggleControl
+                        label={__('Show Pagination Dots', 'charity-m3')}
+                        checked={showPagination}
+                        onChange={(val) => setAttributes({ showPagination: val })}
+                    />
+                    <ToggleControl
+                        label={__('Loop Slides', 'charity-m3')}
+                        checked={loop}
+                        onChange={(val) => setAttributes({ loop: val })}
+                    />
+                    <ToggleControl
+                        label={__('Autoplay', 'charity-m3')}
+                        checked={autoplay}
+                        onChange={(val) => setAttributes({ autoplay: val })}
+                    />
+                    {autoplay && (
+                        <TextControl
+                            label={__('Autoplay Delay (ms)', 'charity-m3')}
+                            type="number"
+                            value={delay}
+                            onChange={(val) => setAttributes({ delay: parseInt(val, 10) })}
+                            step={100}
+                        />
+                    )}
+                </PanelBody>
+            </InspectorControls>
+
+            <div {...blockProps}>
+                <p style={{ margin: '0 0 1rem 0', textAlign: 'center', fontStyle: 'italic', color: '#555' }}>
+                    {__('Carousel Slides (displays horizontally on frontend)', 'charity-m3')}
+                </p>
+                <InnerBlocks
+                    allowedBlocks={ALLOWED_BLOCKS}
+                    template={CAROUSEL_TEMPLATE}
+                    // The 'renderAppender' prop can be used to customize the button for adding new blocks
+                    // renderAppender={() => <InnerBlocks.ButtonBlockAppender />}
+                />
+            </div>
+        </>
+    );
+}

--- a/web/app/themes/charity-m3-theme/app/Blocks/Carousel/render.php
+++ b/web/app/themes/charity-m3-theme/app/Blocks/Carousel/render.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Render callback for the Carousel block.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Content of the inner blocks.
+ * @param WP_Block $block      Block instance.
+ * @return string HTML output for the block.
+ */
+
+// Ensure this file is called only from WordPress context.
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Extract attributes with defaults from block.json
+$slides_per_view = $attributes['slidesPerView'] ?? 1;
+$space_between = $attributes['spaceBetween'] ?? 16;
+$loop = $attributes['loop'] ?? false;
+$autoplay = $attributes['autoplay'] ?? false;
+$delay = $attributes['delay'] ?? 3000;
+$show_navigation = $attributes['showNavigation'] ?? true;
+$show_pagination = $attributes['showPagination'] ?? true;
+$effect = $attributes['effect'] ?? 'slide';
+
+// Construct the Swiper options object
+$swiper_options = [
+    'slidesPerView' => $slides_per_view,
+    'spaceBetween' => $space_between,
+    'loop' => $loop,
+    'effect' => $effect,
+];
+if ($autoplay) {
+    $swiper_options['autoplay'] = [
+        'delay' => $delay,
+        'disableOnInteraction' => false, // Keep playing after user interacts
+    ];
+}
+
+// Get block wrapper attributes (for alignwide, etc.)
+$wrapper_attributes = get_block_wrapper_attributes();
+
+?>
+
+<div <?php echo $wrapper_attributes; ?>>
+    <charity-carousel
+        options='<?php echo esc_attr(json_encode($swiper_options)); ?>'
+        <?php if ($show_navigation): ?>navigation<?php endif; ?>
+        <?php if ($show_pagination): ?>pagination<?php endif; ?>
+    >
+        <?php echo $content; // The rendered HTML of the InnerBlocks ?>
+    </charity-carousel>
+</div>

--- a/web/app/themes/charity-m3-theme/app/Blocks/CarouselBlock.php
+++ b/web/app/themes/charity-m3-theme/app/Blocks/CarouselBlock.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Blocks;
+
+use Roots\Acorn\Application;
+
+class CarouselBlock
+{
+    protected Application $app;
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+        add_action('init', [$this, 'registerBlock']);
+    }
+
+    public function registerBlock()
+    {
+        $editor_script_handle = 'charity-m3-carousel-editor-script';
+        $editor_asset_path = \Roots\asset('scripts/blocks/carousel-editor.js');
+
+        if ($editor_asset_path->exists()) {
+            wp_register_script(
+                $editor_script_handle,
+                $editor_asset_path->uri(),
+                ['wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
+                $editor_asset_path->version(),
+                true
+            );
+        }
+
+        register_block_type_from_metadata(
+            CHARITY_M3_THEME_PATH . 'app/Blocks/Carousel',
+            [
+                'render_callback' => [$this, 'renderCarousel'],
+            ]
+        );
+    }
+
+    public function renderCarousel($attributes, $content, $block)
+    {
+        ob_start();
+        include CHARITY_M3_THEME_PATH . 'app/Blocks/Carousel/render.php';
+        return ob_get_clean();
+    }
+}

--- a/web/app/themes/charity-m3-theme/app/Providers/BlocksServiceProvider.php
+++ b/web/app/themes/charity-m3-theme/app/Providers/BlocksServiceProvider.php
@@ -8,6 +8,7 @@ use App\Blocks\NewsletterSignupBlock;
 use App\Blocks\CardGridBlock;
 use App\Blocks\CardItemBlock;
 use App\Blocks\DonationFormBlock;
+use App\Blocks\CarouselBlock;
 
 class BlocksServiceProvider extends ServiceProvider
 {
@@ -62,6 +63,7 @@ class BlocksServiceProvider extends ServiceProvider
             new CardGridBlock($this->app);
             new CardItemBlock($this->app);
             new DonationFormBlock($this->app);
+            new CarouselBlock($this->app); // Add this
         }
     }
 }

--- a/web/app/themes/charity-m3-theme/resources/scripts/components/charity-button.ts
+++ b/web/app/themes/charity-m3-theme/resources/scripts/components/charity-button.ts
@@ -127,6 +127,20 @@ const buttonStyles = stylex.create({
         boxShadow: 'none',
     }
   },
+  icon: { // New variant for icon-only buttons
+    padding: '0.5rem', // 8px
+    width: '2.5rem', // 40px
+    height: '2.5rem',
+    backgroundColor: `color-mix(in srgb, ${M3SysColors.onSurface} 8%, transparent)`,
+    color: M3SysColors.onSurfaceVariant,
+    borderColor: 'transparent',
+    ':hover': {
+        backgroundColor: `color-mix(in srgb, ${M3SysColors.onSurface} 12%, transparent)`,
+    },
+    ':active': {
+        backgroundColor: `color-mix(in srgb, ${M3SysColors.onSurface} 16%, transparent)`,
+    }
+  },
   disabled: {
     opacity: 0.38, // M3 standard for disabled state
     cursor: 'not-allowed',
@@ -141,7 +155,7 @@ const buttonStyles = stylex.create({
 @customElement('charity-button')
 export class CharityButton extends LitElement {
   @property({ type: String })
-  variant: 'filled' | 'outlined' | 'text' | 'elevated' | 'tonal' = 'filled';
+  variant: 'filled' | 'outlined' | 'text' | 'elevated' | 'tonal' | 'icon' = 'filled';
 
   @property({ type: String })
   href?: string;
@@ -170,6 +184,7 @@ export class CharityButton extends LitElement {
       case 'text': return buttonStyles.text;
       case 'elevated': return buttonStyles.elevated;
       case 'tonal': return buttonStyles.tonal;
+      case 'icon': return buttonStyles.icon;
       default: return buttonStyles.filled;
     }
   }

--- a/web/app/themes/charity-m3-theme/resources/scripts/components/charity-carousel.ts
+++ b/web/app/themes/charity-m3-theme/resources/scripts/components/charity-carousel.ts
@@ -1,0 +1,163 @@
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import * as stylex from '@stylexjs/stylex';
+import { M3SysColors, M3SysShape } from '../tokens';
+
+// Import Swiper and required modules
+import Swiper from 'swiper';
+import { Navigation, Pagination, Autoplay, EffectFade } from 'swiper/modules';
+
+// Re-use our custom button
+import './charity-button';
+
+const styles = stylex.create({
+    wrapper: {
+        position: 'relative',
+        width: '100%',
+        // The swiper-container will be the direct child and will be initialized by Swiper
+    },
+    // Custom styles for navigation buttons
+    navButton: {
+        position: 'absolute',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        zIndex: 10,
+        color: M3SysColors.onPrimary, // White icon on dark overlay
+        backgroundColor: `color-mix(in srgb, ${M3SysColors.scrim} 30%, transparent)`,
+        '::before': { // StyleXJS way to style pseudo-elements or parts if needed
+             // Example: content: '""'
+        },
+        ':hover': {
+            backgroundColor: `color-mix(in srgb, ${M3SysColors.scrim} 50%, transparent)`,
+        },
+        // We will use charity-button, so we can pass variants instead of direct styling here
+    },
+    navButtonPrev: {
+        left: '0.5rem',
+    },
+    navButtonNext: {
+        right: '0.5rem',
+    },
+    // Custom styles for pagination bullets
+    pagination: {
+        position: 'absolute',
+        bottom: '1rem',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 10,
+        // The 'swiper-pagination-bullet' and 'swiper-pagination-bullet-active' classes
+        // are added by Swiper. We target them in global CSS or with ::part if Swiper supported it.
+        // For now, we'll rely on the default Swiper CSS imported in main.scss,
+        // but we can override it with more specific selectors if needed.
+        // For example, in main.scss:
+        // .charity-carousel-pagination .swiper-pagination-bullet-active { background-color: var(--md-sys-color-primary); }
+    },
+});
+
+@customElement('charity-carousel')
+export class CharityCarousel extends LitElement {
+    // A single options object to pass to Swiper
+    @property({ type: Object })
+    options: object = {};
+
+    // Simple props for common controls, which will construct the final options object
+    @property({ type: Boolean })
+    navigation = false;
+
+    @property({ type: Boolean })
+    pagination = false;
+
+    @query('.swiper-container')
+    private swiperContainer!: HTMLElement;
+
+    @query('.swiper-button-prev')
+    private prevButton!: HTMLElement;
+
+    @query('.swiper-button-next')
+    private nextButton!: HTMLElement;
+
+    @query('.swiper-pagination')
+    private paginationEl!: HTMLElement;
+
+    private swiperInstance?: Swiper;
+
+    // Use Light DOM to make it easier for Swiper to find and style elements,
+    // and for slotted content to be found.
+    createRenderRoot() {
+        return this;
+    }
+
+    firstUpdated() {
+        if (!this.swiperContainer) return;
+
+        const defaultOptions = {
+            modules: [Navigation, Pagination, Autoplay, EffectFade],
+            slidesPerView: 1,
+            spaceBetween: 16,
+            loop: false,
+            effect: 'slide',
+            navigation: this.navigation ? {
+                nextEl: this.nextButton,
+                prevEl: this.prevButton,
+            } : false,
+            pagination: this.pagination ? {
+                el: this.paginationEl,
+                clickable: true,
+            } : false,
+        };
+
+        const finalOptions = { ...defaultOptions, ...this.options };
+
+        // Initialize Swiper
+        this.swiperInstance = new Swiper(this.swiperContainer, finalOptions);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        // Destroy Swiper instance to prevent memory leaks
+        this.swiperInstance?.destroy(true, true);
+    }
+
+    render() {
+        // We need to manually wrap slotted children in 'swiper-slide' divs
+        // because Swiper needs this structure.
+        const slides = Array.from(this.children).map(child => html`
+            <div class="swiper-slide">${child}</div>
+        `);
+
+        return html`
+            <div ${stylex.props(styles.wrapper)}>
+                <div class="swiper-container">
+                    <div class="swiper-wrapper">
+                        ${slides}
+                    </div>
+
+                    ${this.pagination ? html`<div class="swiper-pagination charity-carousel-pagination"></div>` : nothing}
+                </div>
+
+                ${this.navigation ? html`
+                    <charity-button
+                        class="swiper-button-prev"
+                        variant="icon"
+                        icon="arrow_back"
+                        label="Previous slide"
+                        ${stylex.props(styles.navButton, styles.navButtonPrev)}
+                    ></charity-button>
+                    <charity-button
+                        class="swiper-button-next"
+                        variant="icon"
+                        icon="arrow_forward"
+                        label="Next slide"
+                        ${stylex.props(styles.navButton, styles.navButtonNext)}
+                    ></charity-button>
+                ` : nothing}
+            </div>
+        `;
+    }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'charity-carousel': CharityCarousel;
+  }
+}

--- a/web/app/themes/charity-m3-theme/resources/scripts/main.ts
+++ b/web/app/themes/charity-m3-theme/resources/scripts/main.ts
@@ -15,6 +15,7 @@ import './components/charity-grid'; // Registers <charity-grid>
 import './components/charity-cta-banner'; // Registers <charity-cta-banner>
 import './components/charity-button'; // Registers <charity-button>
 import './components/charity-donation-form'; // Registers <charity-donation-form>
+import './components/charity-carousel'; // Registers <charity-carousel>
 
 // Example:
 

--- a/web/app/themes/charity-m3-theme/resources/styles/main.scss
+++ b/web/app/themes/charity-m3-theme/resources/styles/main.scss
@@ -2,6 +2,13 @@
  * Main theme SCSS file.
  */
 
+// Import SwiperJS styles
+@import 'swiper/css';
+@import 'swiper/css/navigation'; // If using navigation module
+@import 'swiper/css/pagination'; // If using pagination module
+@import 'swiper/css/effect-fade';   // If using fade effect module
+// Add other effect or module CSS as needed
+
 // 1. Material Design 3 Theming - CSS Custom Properties
 // Ref: https://m3.material.io/styles/color/the-color-system/tokens
 // Ref: https://m3.material.io/styles/typography/tokens

--- a/web/app/themes/charity-m3-theme/webpack.mix.js
+++ b/web/app/themes/charity-m3-theme/webpack.mix.js
@@ -28,8 +28,9 @@ mix.ts('resources/scripts/main.ts', 'public/scripts') // Output: public/scripts/
    .js('app/Blocks/CardGrid/edit.js', 'public/scripts/blocks/card-grid-editor.js')
    .js('app/Blocks/CardItem/edit.js', 'public/scripts/blocks/card-item-editor.js')
    .js('app/Blocks/DonationForm/edit.js', 'public/scripts/blocks/donation-form-editor.js')
+   .js('app/Blocks/Carousel/edit.js', 'public/scripts/blocks/carousel-editor.js') // New: Carousel editor script
    // Gutenberg sidebar plugins
-   .js('app/Blocks/CampaignSidebar/index.js', 'public/scripts/plugins/campaign-sidebar.js') // New: Campaign Sidebar script
+   .js('app/Blocks/CampaignSidebar/index.js', 'public/scripts/plugins/campaign-sidebar.js')
    .sass('resources/styles/main.scss', 'public/styles/main.css') // For global M3 tokens & minimal base styles
    .options({
        postCss: [


### PR DESCRIPTION
Implements a flexible carousel/slider feature using SwiperJS, a new Lit Web Component, and a corresponding Gutenberg block.

Key features:
- **Library Integration:** Added SwiperJS as a dependency and imported its core CSS.
- **`charity-carousel` Lit WC:** A new Web Component that wraps SwiperJS, handles its initialization and destruction, and provides a clean API via props. It uses StyleXJS and the existing `<charity-button>` component for M3-styled navigation.
- **`charity-m3/carousel` Gutenberg Block:**
  - A new container block that uses `<InnerBlocks />`, allowing any block to be used as a slide.
  - Provides extensive options in the Inspector to control carousel behavior (slides per view, space between, loop, autoplay, effects, navigation, pagination).
  - Renders the `<charity-carousel>` Web Component on the frontend with the admin-configured settings.
- **Refinements:** Added a new 'icon' variant to `<charity-button>` for use in carousel navigation.
- Build process, testing plan, and documentation updated for the new feature.