### PR TITLE
feat: Add responsive footer and layout cleanup

### DIFF
--- a/web/app/themes/charity-m3-theme/app/Providers/ThemeServiceProvider.php
+++ b/web/app/themes/charity-m3-theme/app/Providers/ThemeServiceProvider.php
@@ -139,6 +139,42 @@ class ThemeServiceProvider extends ServiceProvider
         add_image_size('hero-large', 1920, 1080, true); // For full-width hero sections
     }
 
+    protected function registerSidebars()
+    {
+        register_sidebar([
+            'name'          => __('Footer Column 1', 'charity-m3'),
+            'id'            => 'footer-col-1',
+            'before_widget' => '<div class="widget %1$s %2$s">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h4 class="widget-title">',
+            'after_title'   => '</h4>',
+        ]);
+        register_sidebar([
+            'name'          => __('Footer Column 2', 'charity-m3'),
+            'id'            => 'footer-col-2',
+            'before_widget' => '<div class="widget %1$s %2$s">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h4 class="widget-title">',
+            'after_title'   => '</h4>',
+        ]);
+        register_sidebar([
+            'name'          => __('Footer Column 3', 'charity-m3'),
+            'id'            => 'footer-col-3',
+            'before_widget' => '<div class="widget %1$s %2$s">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h4 class="widget-title">',
+            'after_title'   => '</h4>',
+        ]);
+        register_sidebar([
+            'name'          => __('Footer Column 4', 'charity-m3'),
+            'id'            => 'footer-col-4',
+            'before_widget' => '<div class="widget %1$s %2$s">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h4 class="widget-title">',
+            'after_title'   => '</h4>',
+        ]);
+    }
+
     /**
      * Enqueue theme assets.
      * This is a basic example. A more robust solution might use Acorn's asset management.

--- a/web/app/themes/charity-m3-theme/resources/styles/main.scss
+++ b/web/app/themes/charity-m3-theme/resources/styles/main.scss
@@ -358,3 +358,66 @@ hr {
   top: 1rem;
   left: 1rem;
 }
+
+.site-footer {
+    background-color: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface-container);
+    padding: 3rem 1rem;
+
+    .widget {
+        margin-bottom: 1.5rem;
+    }
+
+    .widget-title {
+        font-size: 1.25rem;
+        font-weight: 500;
+        color: var(--md-sys-color-on-surface);
+        margin-bottom: 1rem;
+    }
+
+    ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+
+        li {
+            margin-bottom: 0.5rem;
+
+            a {
+                color: var(--md-sys-color-on-surface-variant);
+                text-decoration: none;
+
+                &:hover {
+                    color: var(--md-sys-color-primary);
+                    text-decoration: underline;
+                }
+            }
+        }
+    }
+
+    .footer-navigation {
+        ul {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 2rem;
+
+        @media (min-width: 640px) {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        @media (min-width: 1024px) {
+            grid-template-columns: repeat(4, 1fr);
+        }
+    }
+
+    .border-t {
+        border-top: 1px solid var(--md-sys-color-outline-variant);
+    }
+}

--- a/web/app/themes/charity-m3-theme/resources/views/components/m3-footer.blade.php
+++ b/web/app/themes/charity-m3-theme/resources/views/components/m3-footer.blade.php
@@ -1,0 +1,34 @@
+<footer class="site-footer bg-gray-800 text-white py-12">
+    <div class="container mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+            <div class="footer-col-1">
+                @if (is_active_sidebar('footer-col-1'))
+                    @php dynamic_sidebar('footer-col-1') @endphp
+                @endif
+            </div>
+            <div class="footer-col-2">
+                @if (is_active_sidebar('footer-col-2'))
+                    @php dynamic_sidebar('footer-col-2') @endphp
+                @endif
+            </div>
+            <div class="footer-col-3">
+                @if (is_active_sidebar('footer-col-3'))
+                    @php dynamic_sidebar('footer-col-3') @endphp
+                @endif
+            </div>
+            <div class="footer-col-4">
+                @if (is_active_sidebar('footer-col-4'))
+                    @php dynamic_sidebar('footer-col-4') @endphp
+                @endif
+            </div>
+        </div>
+        <div class="mt-8 border-t border-gray-700 pt-8 flex flex-col md:flex-row justify-between items-center">
+            <p class="text-sm">&copy; {{ date('Y') }} {{ get_bloginfo('name') }}. All Rights Reserved.</p>
+            @if (has_nav_menu('footer_navigation'))
+                <nav class="footer-navigation mt-4 md:mt-0">
+                    {!! wp_nav_menu(['theme_location' => 'footer_navigation', 'menu_class' => 'flex space-x-4', 'echo' => false]) !!}
+                </nav>
+            @endif
+        </div>
+    </div>
+</footer>

--- a/web/app/themes/charity-m3-theme/resources/views/layouts/app.blade.php
+++ b/web/app/themes/charity-m3-theme/resources/views/layouts/app.blade.php
@@ -20,7 +20,7 @@
       @yield('content')
     </main>
 
-    @include('partials.footer')
+    <x-m3-footer />
   </div>
 
   @php(wp_footer())


### PR DESCRIPTION
This commit adds a responsive, widgetized footer to the theme and cleans up the layout structure.

- A new "Footer" widget area with four columns has been registered.
- A new `<x-m3-footer>` Blade component has been created to render the footer.
- The main layout file has been updated to use the new footer component.
- Responsive styles have been added to ensure the footer and layout look great on all devices.